### PR TITLE
Add client list, fix channel race, hjoin, tests

### DIFF
--- a/cherrysrv/commands.go
+++ b/cherrysrv/commands.go
@@ -281,6 +281,7 @@ func do_login(clt *Client, args string) {
 	mainChannel, _ := CHANNELS.Load("#main")
 
 	mainChannel.addClient(clt)
+	clt.Channels = append(clt.Channels, mainChannel)
 
 	/* Update player */
 
@@ -331,6 +332,7 @@ func do_join(clt *Client, args string) {
 
 	if ok {
 		channel.addClient(clt)
+		clt.Channels = append(clt.Channels, channel)
 		channel.Say(clt, "joined the channel")
 
 		return
@@ -347,6 +349,7 @@ func do_join(clt *Client, args string) {
 
 	NewChannel := newChannel(channelName, false)
 	NewChannel.addClient(clt)
+	clt.Channels = append(clt.Channels, NewChannel)
 
 	CHANNELS.Store(NewChannel.Key(), NewChannel)
 	DEBUG.Printf("adding %s to CHANNELS", NewChannel)
@@ -374,6 +377,7 @@ func do_hjoin(clt *Client, args string) {
 
 	if ok {
 		channel.addClient(clt)
+		clt.Channels = append(clt.Channels, channel)
 		channel.Say(clt, "hjoined the channel")
 
 		return
@@ -389,7 +393,8 @@ func do_hjoin(clt *Client, args string) {
 	}
 
 	NewChannel := newChannel(channelName, true)
-	channel.addClient(clt)
+	NewChannel.addClient(clt)
+	clt.Channels = append(clt.Channels, NewChannel)
 
 	CHANNELS.Store(NewChannel.Key(), NewChannel)
 	DEBUG.Printf("adding %s to CHANNELS", NewChannel)
@@ -425,6 +430,7 @@ func do_leave(clt *Client, args string) {
 
 		channel.Say(clt, "left the channel")
 		channel.removeClient(clt)
+		clt.RemoveChannel(channel)
 
 		return
 	}

--- a/cherrysrv/utils.go
+++ b/cherrysrv/utils.go
@@ -48,9 +48,10 @@ func ValidUsername(username string) (validusername string, err error) {
 		return notvalid, fmt.Errorf("username cannot be longer than 16 chars")
 	}
 
-	if isDigit(username[1]) {
+	// this test is no longer necessary due to @ requirement
+	/*if isDigit(username[1]) {
 		return notvalid, fmt.Errorf("username cannot start with a number")
-	}
+	}*/
 
 	if !isASCIIPrintable(username[1:]) {
 		return notvalid, fmt.Errorf("username can only contain ASCII chars and numbers")

--- a/cherrysrv/utils_test.go
+++ b/cherrysrv/utils_test.go
@@ -43,12 +43,12 @@ func TestValidUsername(t *testing.T) {
 		wantErr           bool
 	}{
 		//		{"empty string", "", NOSTRING, true},
-		{"valid name", "JohnnyCash", "JohnnyCash", false},
-		{"valid name w/numbers", "JohnnyCash12", "JohnnyCash12", false},
-		{"name with space", "Johnny Cash", NOSTRING, true},
+		{"valid name", "@JohnnyCash", "@JohnnyCash", false},
+		{"valid name w/numbers", "@JohnnyCash12", "@JohnnyCash12", false},
+		{"name with space", "@Johnny Cash", NOSTRING, true},
 		{"srv", "srv", NOSTRING, true},
-		{"name too long", "a1234567890123456", NOSTRING, true},
-		{"name at limit", "a123456789012345", "a123456789012345", false},
+		{"name too long", "@a1234567890123456", NOSTRING, true},
+		{"name at limit", "@a12345678901234", "@a12345678901234", false},
 		{"name starts w/number", "1John", NOSTRING, true},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixed a bug with hjoin, username tests to include the @, and removed the test for a number as the first character due to that being an unnecessary check after testing for the @ above.

I handled the two TODOs:
Add after the remove is handled by just writing the channel back into the global index. There is still a race condition where a user could /join during the time that the channel was deleted but while the add was still queued, so it is not completely fixed; I think it might be safest to just use a regular map and use an RWLock Mutex for any possible operation.

I added a client channel slice. I liberally used appends, so not sure how much of an optimization it actually was.