### PR TITLE
Fujitzee - Add support for Binary response

### DIFF
--- a/fujinet-game-system/fujitzee/server/gameLogic.go
+++ b/fujinet-game-system/fujitzee/server/gameLogic.go
@@ -31,7 +31,7 @@ const (
 	PLAYER_PING_TIMEOUT = time.Minute * time.Duration(-5)
 
 	PROMPT_WAITING_FOR_MORE_PLAYERS = "Waiting for players"
-	PROMPT_WAITING_ON_READY         = "Waiting for everyone to ready up."
+	PROMPT_WAITING_ON_READY         = "Waiting for everyone to ready up"
 	PROMPT_STARTING_IN              = "Starting in "
 	PROMPT_YOUR_TURN                = "Your turn"
 	PROMPT_GAME_ABORTED             = "The game was aborted early"

--- a/fujinet-game-system/fujitzee/server/main.go
+++ b/fujinet-game-system/fujitzee/server/main.go
@@ -228,6 +228,9 @@ func apiTables(c *gin.Context) {
 				humanPlayerSlots, humanPlayerCount := state.getHumanPlayerCountInfo()
 				table.CurPlayers = humanPlayerCount
 				table.MaxPlayers = humanPlayerSlots
+				if table.CurPlayers > table.MaxPlayers {
+					table.CurPlayers = table.MaxPlayers
+				}
 				tableOutput = append(tableOutput, table)
 			}
 		}

--- a/fujinet-game-system/fujitzee/server/util.go
+++ b/fujinet-game-system/fujitzee/server/util.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"encoding/binary"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -51,7 +53,111 @@ func serializeResults(c *gin.Context, obj any) {
 
 		c.String(http.StatusOK, jsonResult)
 
+	} else if c.Query("bin") == "1" {
+		var buf []byte
+		var val int
+		bigEndian := c.Query("be") == "1"
+
+		// Binary version of Table list
+		if tables, ok := obj.([]GameTable); ok {
+			buf = append(buf, byte(len(tables)))
+			for _, o := range tables {
+				buf = appendFixedLengthString(buf, o.Table, 8)
+				buf = appendFixedLengthString(buf, o.Name, 20)
+				buf = appendFixedLengthString(buf, fmt.Sprintf("%d / %d", o.CurPlayers, o.MaxPlayers), 5)
+			}
+		}
+
+		// Binary version of GameState
+		if o, ok := obj.(*GameState); ok {
+			buf = append(buf, byte(len(o.Players)))
+			buf = appendFixedLengthString(buf, o.Name, 20)
+			buf = appendFixedLengthString(buf, o.Prompt, 40)
+			buf = append(buf,
+				byte(o.Round),
+				byte(o.RollsLeft),
+				byte(o.ActivePlayer),
+				byte(o.MoveTime),
+				byte(o.Viewing))
+			buf = appendFixedLengthString(buf, o.Dice, 5)
+			buf = appendFixedLengthString(buf, o.KeepRoll, 5)
+			for i := 0; i < 15; i++ {
+				if i < len(o.ValidScores) {
+					val = o.ValidScores[i]
+				} else {
+					val = 0
+				}
+				buf = append(buf, byte(val))
+			}
+			for i := 0; i < len(o.Players); i++ {
+				buf = appendFixedLengthString(buf, o.Players[i].Name, 8)
+				buf = append(buf, byte(o.Players[i].Alias))
+
+				for j := 0; j < 16; j++ {
+					if j < len(o.Players[i].Scores) {
+						val = o.Players[i].Scores[j]
+					} else {
+						val = 0
+					}
+					if bigEndian {
+						buf = binary.BigEndian.AppendUint16(buf, uint16(val))
+					} else {
+						buf = binary.LittleEndian.AppendUint16(buf, uint16(val))
+					}
+				}
+			}
+		}
+
+		c.Data(http.StatusOK, "application/octet-stream", buf)
 	} else {
 		c.JSON(http.StatusOK, obj)
 	}
+}
+
+// Returns a byte slice equal to the maxLen+1, padded with zeros
+// The extra byte is added to terminate the string
+func appendFixedLengthString(buf []byte, s string, maxLen int) []byte {
+
+	// Truncate string to honor contract
+	if len(s) > maxLen {
+		s = s[:maxLen]
+	}
+
+	// Convert to lowercase
+	s = strings.ToLower(s)
+
+	buf = append(buf, s...)
+	maxLen -= len(s)
+	for maxLen >= 0 {
+		buf = append(buf, 0)
+		maxLen--
+	}
+	return buf
+}
+
+// ternary if operator
+func ifFuncElseFunc[T any](condition bool, yes func() T, no func() T) T {
+	if condition {
+		return yes()
+	}
+
+	return no()
+}
+
+// ternary if operator
+func ifFuncElse[T any](condition bool, yes func() T, no T) T {
+	if condition {
+		return yes()
+	}
+
+	return no
+}
+
+// ternary if operator
+func ifElse[T any](condition bool, yes T, no T) T {
+	if condition {
+		return yes
+	}
+
+	return no
 }


### PR DESCRIPTION
Add support for binary format (`&bin=1`), for space savings on the latest Fujitzee 8 bit clients. Supports little (default) and big (`&be=1`) endian .